### PR TITLE
Add translatable setting to export

### DIFF
--- a/thearchitect/services/TheArchitectService.php
+++ b/thearchitect/services/TheArchitectService.php
@@ -2693,6 +2693,7 @@ class TheArchitectService extends BaseApplicationComponent
                     'instructions' => $field->instructions,
                     'required' => $field->required,
                     'type' => $field->type,
+                    'translatable' => (bool)$field->translatable,
                     'typesettings' => $field->settings,
                 ];
                 if ($includeID) {


### PR DESCRIPTION
Adds the setting to the export, so when it will be imported the setting will be set correctly to the value it had from the export.